### PR TITLE
Refactor List endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NYU DevOps Project Template
+# NYU DevOps Project: Wishlists Service
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python](https://img.shields.io/badge/Language-Python-blue.svg)](https://python.org/)

--- a/service/routes.py
+++ b/service/routes.py
@@ -43,8 +43,8 @@ def index():
 ######################################################################
 
 
-# GETs Wishlist with a specific wishlist_id
-@app.route("/wishlists/<int:wishlist_id>", methods=["GET"])
+# Lists all the Items in a Wishlist
+@app.route("/wishlists/<int:wishlist_id>/items", methods=["GET"])
 def get_wishlists(wishlist_id):
     """
     Retrieve a single Wishlist

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -80,7 +80,7 @@ class TestWishlistService(TestCase):
 
     def test_get_wishlist_not_found(self):
         """It should not Read a Wishlist thats not found"""
-        response = self.app.get(f"{BASE_URL}/0")
+        response = self.app.get(f"{BASE_URL}/0/items")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         data = response.get_json()
         self.assertIn("was not found", data["message"])
@@ -160,7 +160,7 @@ class TestWishlistService(TestCase):
         response = self.app.delete(f"{BASE_URL}/{wishlist.id}")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         # make sure the wishlist is deleted
-        response = self.app.get(f"{BASE_URL}/{wishlist.id}")
+        response = self.app.get(f"{BASE_URL}/{wishlist.id}/items")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)        
 
 ######################################################################
@@ -261,7 +261,7 @@ class TestItemService(TestCase):
         )
         self.assertEqual(item_two_response.status_code, status.HTTP_201_CREATED)
         
-        resp = self.app.get(f"{BASE_URL}/{wishlist.id}", content_type="application/json")
+        resp = self.app.get(f"{BASE_URL}/{wishlist.id}/items", content_type="application/json")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         data = resp.get_json()
         self.assertEqual(len(data), 2)
@@ -281,7 +281,7 @@ class TestItemService(TestCase):
         item_id = data["id"]
 
         # make sure item exists before delete
-        response = self.app.get(f"{BASE_URL}/{wishlist.id}", content_type="application/json")
+        response = self.app.get(f"{BASE_URL}/{wishlist.id}/items", content_type="application/json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         items = response.get_json()[0]        
         self.assertEqual(items['id'], item_id)
@@ -291,7 +291,7 @@ class TestItemService(TestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         # make sure item does not exist after delete
-        response = self.app.get(f"{BASE_URL}/{wishlist.id}", content_type="application/json")
+        response = self.app.get(f"{BASE_URL}/{wishlist.id}/items", content_type="application/json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         items = response.get_json()
         self.assertEqual(len(items), 0)


### PR DESCRIPTION
Refactoring our `GET /wishlists/<wishlist_id>/` to `GET /wishlists/<wishlist_id>/items` since it actually implemented the same functionality. Modified corresponding tests as well.

<img width="699" alt="image" src="https://user-images.githubusercontent.com/25875077/227725548-ea640dbb-5925-4ea2-a1e3-9da445392937.png">
<img width="462" alt="image" src="https://user-images.githubusercontent.com/25875077/227725584-d202b0fe-621e-48e8-a4eb-e377e73a3d15.png">
