### PR TITLE
Refactor Read endpoints for Wishlist and item

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ run command as follow in command line
 nosetests
 ```
 
-Current coverage is 95%
-
 ## Contents
 
 The project contains the following:
@@ -61,8 +59,7 @@ service/                     - service python package
 tests/                       - test cases package
 ├── __init__.py              - package initializer
 ├── factories.py             - test factory to make testing objects
-├── test_items_model.py      - test suite for item models
-├── test_wishlists_models.py - test suite for wishlist models
+├── test_models.py           - test suite for models
 ├── test_cli_commands.py     - test suite for cli commands
 └── test_routes.py           - test suite for service routes
 ```
@@ -73,7 +70,7 @@ Route | Operation | Description
 -- | -- | --
 /healthcheck | | Service Healthcheck
 / | root index | Root URL returns service name
-GET /wishlists/`<wishlist_id>` | READ | Show a single wishlist
+GET /wishlists/`<wishlist_id>`/items | LIST | List items in a wishlist
 GET /wishlists | LIST | Show all wishlists
 POST /wishlists | CREATE | Create new Wishlist
 PUT /wishlists/`<wishlist_id>` | UPDATE | Update wishlist

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Route | Operation | Description
 -- | -- | --
 /healthcheck | | Service Healthcheck
 / | root index | Root URL returns service name
+GET /wishlists/`<wishlist_id>` | READ | Reads a single wishlist with given ID
+GET /wishlists/`<wishlist_id>`/items/`<item_id>` | READ | Read an item from a wishlist
 GET /wishlists/`<wishlist_id>`/items | LIST | List items in a wishlist
 GET /wishlists | LIST | Show all wishlists
 POST /wishlists | CREATE | Create new Wishlist

--- a/service/routes.py
+++ b/service/routes.py
@@ -43,9 +43,50 @@ def index():
 ######################################################################
 
 
+# Get a wishlist
+@app.route("/wishlists/<int:wishlist_id>", methods=["GET"])
+def get_wishlist(wishlist_id):
+    """
+    Read a single Wishlist based on it's ID
+    """
+    app.logger.info("Request for Wishlist with id: %s", wishlist_id)
+    wishlist = Wishlist.find(wishlist_id)
+    if not wishlist:
+        abort(status.HTTP_404_NOT_FOUND, f"Wishlist with id '{wishlist_id}' was not found.")
+    app.logger.info("Returning wishlist: %s", wishlist.id)
+    return make_response(jsonify(wishlist.serialize()), status.HTTP_200_OK)
+
+
+@app.route("/wishlists/<int:wishlist_id>/items/<int:item_id>", methods=["GET"])
+def get_item(wishlist_id, item_id):
+    """
+    Retrieve an item from a Wishlist
+    """
+    app.logger.info("Request to read an Item %s from Wishlist with id: %s", item_id, wishlist_id)
+
+    # See if the wishlist exists and abort if it doesn't
+    wishlist = Wishlist.find(wishlist_id)
+    if not wishlist:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Wishlist with id '{wishlist_id}' was not found.",
+        )
+
+    # Read an item with item_id
+    result = Item.find_by_wishlist_and_item_id(wishlist_id, item_id)
+    if not result:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Item with id '{item_id}' was not found.",
+        )
+    # Prepare a message to return
+    message = result.serialize()
+    return make_response(jsonify(message), status.HTTP_200_OK)
+
+
 # Lists all the Items in a Wishlist
 @app.route("/wishlists/<int:wishlist_id>/items", methods=["GET"])
-def get_wishlists(wishlist_id):
+def list_wishlist_items(wishlist_id):
     """
     Retrieve a single Wishlist
     This endpoint will return a Wishlist based on it's id
@@ -87,7 +128,7 @@ def create_wishlist():
     wishlist.deserialize(request.get_json())
     wishlist.create()
     message = wishlist.serialize()
-    location_url = url_for("get_wishlists", wishlist_id=wishlist.id, _external=True)
+    location_url = url_for("list_wishlist_items", wishlist_id=wishlist.id, _external=True)
 
     app.logger.info("Wishlist with ID [%s] created.", wishlist.id)
     return jsonify(message), status.HTTP_201_CREATED, {"Location": location_url}


### PR DESCRIPTION
Added below 2 Read endpoints and their tests as the previously added endpoints were basically for List.
1. `/wishlists/<int:wishlist_id>`
2. `/wishlists/<int:wishlist_id>/items/<int:item_id>`

Test results
<img width="582" alt="image" src="https://user-images.githubusercontent.com/25661064/228772802-393e5990-7682-470d-8fa7-8f292b282286.png">
