### PR TITLE
Improve input validation by including parameter data type

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -100,7 +100,7 @@ class WishlistResource(Resource):
         """
 
         app.logger.info("Request to get wishlist with id %s", wishlist_id)
-        
+       
         wishlist = Wishlist.find(wishlist_id)
 
         if not wishlist:

--- a/service/routes.py
+++ b/service/routes.py
@@ -82,7 +82,7 @@ def index():
 ######################################################################
 
 
-@api.route("/wishlists/<wishlist_id>")
+@api.route("/wishlists/<int:wishlist_id>")
 @api.param("wishlist_id", "The Wishlist identifier")
 class WishlistResource(Resource):
     """Handles all routes for the wishlist model."""
@@ -100,7 +100,7 @@ class WishlistResource(Resource):
         """
 
         app.logger.info("Request to get wishlist with id %s", wishlist_id)
-
+        
         wishlist = Wishlist.find(wishlist_id)
 
         if not wishlist:
@@ -209,7 +209,7 @@ class WishlistCollection(Resource):
 ######################################################################
 
 
-@api.route("/wishlists/<wishlist_id>/clear", strict_slashes=False)
+@api.route("/wishlists/<int:wishlist_id>/clear", strict_slashes=False)
 @api.param("wishlist_id", "The wishlist ID")
 class ClearWishlistResource(Resource):
     """ Clear action on a Wishlist """

--- a/service/routes.py
+++ b/service/routes.py
@@ -100,7 +100,7 @@ class WishlistResource(Resource):
         """
 
         app.logger.info("Request to get wishlist with id %s", wishlist_id)
-       
+
         wishlist = Wishlist.find(wishlist_id)
 
         if not wishlist:


### PR DESCRIPTION
After testing on Swagger, I found that the only time a 500 server error occurred was when the `wishlist_id` was assigned as a string type. Resolved this issue by adding input validation to the API.